### PR TITLE
Renamed xViewer.onRemove() to .off()

### DIFF
--- a/Xbim.WeXplorer/Viewer/xbim-viewer.debug.js
+++ b/Xbim.WeXplorer/Viewer/xbim-viewer.debug.js
@@ -168,7 +168,7 @@ function xViewer(canvas) {
     this._stylingChanged = true;
 
     //dictionary of named events which can be registered and unregistered by using '.on('eventname', callback)'
-    // and '.onRemove('eventname', callback)'. Registered callbacks are triggered by the viewer when important events occure.
+    // and '.off('eventname', callback)'. Registered callbacks are triggered by the viewer when important events occure.
     this._events = {};
 
     //pointers to uniforms in shaders
@@ -1230,7 +1230,7 @@ xViewer.prototype.stop = function () {
 
 /**
 * Use this method to register to events of the viewer like {@link xViewer#pick pick}, {@link xViewer#mouseDown mouseDown}, {@link xViewer#loaded loaded} and others. You can define arbitrary number
-* of event handlers for any event. You can remove handler by calling {@link xViewer#onRemove onRemove()} method.
+* of event handlers for any event. You can remove handler by calling {@link xViewer#off off()} method.
 *
 * @function xViewer#on
 * @param {String} eventName - Name of the event you would like to listen to.
@@ -1245,19 +1245,19 @@ xViewer.prototype.on = function (eventName, callback) {
 };
 
 /**
-* Use this method to unregisted handlers from events. You can add event handlers by call to {@link xViewer#on on()} method.
+* Use this method to unregisted handlers from events. You can add event handlers by calling the {@link xViewer#on on()} method.
 *
-* @function xViewer#onRemove
+* @function xViewer#off
 * @param {String} eventName - Name of the event
 * @param {Object} callback - Handler to be removed
 */
-xViewer.prototype.onRemove = function (eventName, callback) {
+xViewer.prototype.off = function (eventName, callback) {
     var events = this._events;
     var callbacks = events[eventName];
     if (!callbacks) {
         return;
     }
-    var index = callbacks.indexOf(callback)
+    var index = callbacks.indexOf(callback);
     if (index >= 0) {
         callbacks.splice(index, 1);
     }


### PR DESCRIPTION
To make it more familiar to jQuery developers, as the event handlers are attached with .on(), I propose removing them with .off() instead of .onRemove()

Not only does this make the event handling methods more familiar to those who use jQuery, but .onRemove() almost sounds like you are attaching a handler to a 'remove' event.