### PR TITLE
Navigate failsafe

### DIFF
--- a/Xbim.WeXplorer/Viewer/xbim-viewer.debug.js
+++ b/Xbim.WeXplorer/Viewer/xbim-viewer.debug.js
@@ -116,12 +116,6 @@ function xViewer(canvas) {
     */
     this.renderingMode = 'normal';
 
-    /**
-    * When focusing on an entity, this method will reduce the zoom distance relational to the size of the model.
-    * @member {Number} xViewer#autoZoomRelationalDistance
-    */
-    this.autoZoomRelationalDistance = 0;
-
     /** 
     * Clipping plane [a, b, c, d] defined as normal equation of the plane ax + by + cz + d = 0. [0,0,0,0] is for no clipping plane.
     * @member {Number[]} xViewer#_clippingPlane
@@ -200,8 +194,6 @@ function xViewer(canvas) {
 
     //Navigation settings - coordinates in the WCS of the origin used for orbiting and panning
     this._origin = [0, 0, 0]
-    //Default distance when the model first loads, used to get idea of model size
-    this._baseDistance = 0;
     //Default distance for default views (top, bottom, left, right, front, back)
     this._distance = 0;
     //shader program used for rendering
@@ -503,8 +495,7 @@ xViewer.prototype.setCameraTarget = function (prodId) {
     var setDistance = function (bBox) {
         var size = Math.max(bBox[3], bBox[4], bBox[5]);
         var ratio = Math.max(viewer._width, viewer._height) / Math.min(viewer._width, viewer._height);
-        viewer._distance = size / Math.tan(viewer.perspectiveCamera.fov * Math.PI / 360.0) * ratio * 1.2;
-        if(viewer._baseDistance) viewer._distance += viewer._baseDistance * viewer.autoZoomRelationalDistance;
+        viewer._distance = size / Math.tan(viewer.perspectiveCamera.fov * Math.PI / 360.0) * ratio * 1.0;
     }
 
     //set navigation origin and default distance to the product BBox
@@ -535,7 +526,6 @@ xViewer.prototype.setCameraTarget = function (prodId) {
             if (region) {
                 this._origin = [region.centre[0], region.centre[1], region.centre[2]]
                 setDistance(region.bbox);
-                if(!viewer._baseDistance) viewer._baseDistance = viewer._distance;
             }
         }
         return true;

--- a/Xbim.WeXplorer/Viewer/xbim-viewer.debug.js
+++ b/Xbim.WeXplorer/Viewer/xbim-viewer.debug.js
@@ -116,6 +116,12 @@ function xViewer(canvas) {
     */
     this.renderingMode = 'normal';
 
+    /**
+    * When focusing on an entity, this method will reduce the zoom distance relational to the size of the model.
+    * @member {Number} xViewer#autoZoomRelationalDistance
+    */
+    this.autoZoomRelationalDistance = 0;
+
     /** 
     * Clipping plane [a, b, c, d] defined as normal equation of the plane ax + by + cz + d = 0. [0,0,0,0] is for no clipping plane.
     * @member {Number[]} xViewer#_clippingPlane
@@ -194,6 +200,8 @@ function xViewer(canvas) {
 
     //Navigation settings - coordinates in the WCS of the origin used for orbiting and panning
     this._origin = [0, 0, 0]
+    //Default distance when the model first loads, used to get idea of model size
+    this._baseDistance = 0;
     //Default distance for default views (top, bottom, left, right, front, back)
     this._distance = 0;
     //shader program used for rendering
@@ -495,7 +503,8 @@ xViewer.prototype.setCameraTarget = function (prodId) {
     var setDistance = function (bBox) {
         var size = Math.max(bBox[3], bBox[4], bBox[5]);
         var ratio = Math.max(viewer._width, viewer._height) / Math.min(viewer._width, viewer._height);
-        viewer._distance = size / Math.tan(viewer.perspectiveCamera.fov * Math.PI / 360.0) * ratio * 1.0;
+        viewer._distance = size / Math.tan(viewer.perspectiveCamera.fov * Math.PI / 360.0) * ratio * 1.2;
+        if(viewer._baseDistance) viewer._distance += viewer._baseDistance * viewer.autoZoomRelationalDistance;
     }
 
     //set navigation origin and default distance to the product BBox
@@ -526,6 +535,7 @@ xViewer.prototype.setCameraTarget = function (prodId) {
             if (region) {
                 this._origin = [region.centre[0], region.centre[1], region.centre[2]]
                 setDistance(region.bbox);
+                if(!viewer._baseDistance) viewer._baseDistance = viewer._distance;
             }
         }
         return true;

--- a/Xbim.WeXplorer/Viewer/xbim-viewer.debug.js
+++ b/Xbim.WeXplorer/Viewer/xbim-viewer.debug.js
@@ -869,6 +869,7 @@ xViewer.prototype._initMouseEvents = function () {
     }
 
     function navigate(type, deltaX, deltaY) {
+        if(!viewer._handles || !viewer._handles[0]) return;
         //translation in WCS is position from [0, 0, 0]
         var origin = viewer._origin;
         var camera = viewer.getCameraPosition();

--- a/Xbim.WeXplorer/Viewer/xbim-viewer.debug.js
+++ b/Xbim.WeXplorer/Viewer/xbim-viewer.debug.js
@@ -548,8 +548,21 @@ xViewer.prototype.setCameraTarget = function (prodId) {
 * @param {Object} settings - Object containing key - value pairs
 */
 xViewer.prototype.set = function (settings) {
-    for (key in settings) {
-        this[key] = settings[key];
+    if(arguments.length === 2)
+    {
+        var sets = {};
+        sets[arguments[0]] = arguments[1];
+        this.set(sets);
+    }
+    else
+    {
+        for(var key in settings)
+        {
+            if(settings.hasOwnProperty(key))
+            {
+                this[key] = settings[key];
+            }
+        }
     }
 };
 

--- a/Xbim.WeXplorer/Viewer/xbim-viewer.debug.js
+++ b/Xbim.WeXplorer/Viewer/xbim-viewer.debug.js
@@ -538,21 +538,8 @@ xViewer.prototype.setCameraTarget = function (prodId) {
 * @param {Object} settings - Object containing key - value pairs
 */
 xViewer.prototype.set = function (settings) {
-    if(arguments.length === 2)
-    {
-        var sets = {};
-        sets[arguments[0]] = arguments[1];
-        this.set(sets);
-    }
-    else
-    {
-        for(var key in settings)
-        {
-            if(settings.hasOwnProperty(key))
-            {
-                this[key] = settings[key];
-            }
-        }
+    for (key in settings) {
+        this[key] = settings[key];
     }
 };
 


### PR DESCRIPTION
Added failsafe to xViewer navigate function when model handles are unavailable. Might be better suited to using some sort of `onerror()` integration though?