### PR TITLE
Fixing bug which causes WebGL warning: "RENDER WARNING: Render count or primcount is 0"

### DIFF
--- a/Xbim.WeXplorer/Viewer/xbim-model-handle.debug.js
+++ b/Xbim.WeXplorer/Viewer/xbim-model-handle.debug.js
@@ -159,8 +159,11 @@ xModelHandle.prototype.draw = function (mode) {
     }
 
     if (mode === "transparent") {
-        gl.drawArrays(gl.TRIANGLES, this._model.transparentIndex, this.count - this._model.transparentIndex);
-        return;
+        var transparentIndexCount = this.count - this._model.transparentIndex;
+
+        if (transparentIndexCount > 0) {
+            gl.drawArrays(gl.TRIANGLES, this._model.transparentIndex, this.count - this._model.transparentIndex);
+        }
     }
     
 };

--- a/Xbim.WeXplorer/Viewer/xbim-model-handle.debug.js
+++ b/Xbim.WeXplorer/Viewer/xbim-model-handle.debug.js
@@ -162,7 +162,7 @@ xModelHandle.prototype.draw = function (mode) {
         var transparentIndexCount = this.count - this._model.transparentIndex;
 
         if (transparentIndexCount > 0) {
-            gl.drawArrays(gl.TRIANGLES, this._model.transparentIndex, this.count - this._model.transparentIndex);
+            gl.drawArrays(gl.TRIANGLES, this._model.transparentIndex, transparentIndexCount);
         }
     }
     


### PR DESCRIPTION
I noticed that for some models the library produces WebGL tons of warning:

`RENDER WARNING: Render count or primcount is 0`

After debugging I discovered that it's related to the transparent rendering mode. I don't know the exact reason of this bug, but it looks like it occurs when we load a model which doesn't have any transparent objects.

Fortunately the fix was quite simple and safe :).

You can get the models that produce this warning below, so you can reproduce it in your environment:
[models.zip](https://github.com/xBimTeam/XbimWebUI/files/1824616/models.zip)
