### PR TITLE
Fix the getCameraPosition() method

### DIFF
--- a/Xbim.WeXplorer/Viewer/viewer.ts
+++ b/Xbim.WeXplorer/Viewer/viewer.ts
@@ -1626,14 +1626,8 @@ export class Viewer {
     * @function Viewer#getCameraPosition
     */
     public getCameraPosition(): Float32Array {
-        var transform = mat4.create();
-        mat4.multiply(transform, this._pMatrix, this.mvMatrix);
-        var inv = mat4.create()
-        mat4.invert(inv, transform);
         var eye = vec3.create();
-        vec3.transformMat4(eye, vec3.create(), inv);
-
-        return eye;
+        return vec3.transformMat4(eye, eye, mat4.invert(mat4.create(), this.mvMatrix));
     }
 
     /**


### PR DESCRIPTION
The mvMatrix matrix purpose is to transform world coordinates into the
camera's own coordinates. The perspective matrix is then used to
transform those coordinates into the canvas space, it doesn't care about
the camera position :-).

To test this change, you can try feeding the return value of
getCameraPosition to setCameraPosition. Previously, there was a slight
move of the camera, now it stays still (minus the potential floating
point rounding error).