### PR TITLE
fix: guard against empty regions in getCameraDistanceFromRegion

### DIFF
--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -1711,6 +1711,11 @@ export class Viewer {
 
     private getCameraDistanceFromRegion(): {near: number, far: number, size: number} {
         let region = this.getMergedRegion();
+
+        if (!region.bbox || region.bbox.length === 0) {
+            return { near: 0, far: 0, size: 0};
+        }
+
         let camera = this.getCameraPosition();
         let viewDir = vec3.normalize(vec3.create(), this.getCameraDirection());
         let size = BBox.getDiagonalSize(region.bbox);


### PR DESCRIPTION
The navigation is broken when loading a model with no geometry first and try to load a model with geometry afterwards. 

How to replicate:
 - Load an empty model
 - Load a model with geometry next
 
https://user-images.githubusercontent.com/50090593/221417622-4a72fd60-98e0-423d-95ee-973305b66d95.mp4

