### PR TITLE
Fix hardcoded viewer ID in Icons plugin

### DIFF
--- a/src/plugins/DataVisualization/Icons/icons.ts
+++ b/src/plugins/DataVisualization/Icons/icons.ts
@@ -247,7 +247,7 @@ export class Icons implements IPlugin {
     }
 
     private render() {
-        const canvas = document.getElementById('viewer');
+        const canvas = this._viewer.canvas;
        
         if(canvas && this._icons) {
     


### PR DESCRIPTION
Replaced the hardcoded canvas ID with a reference to the viewer’s canvas:
// const canvas = document.getElementById('viewer'); 
const canvas = this._viewer.canvas;

The canvas can have a different id than just "viewer".  
Classic “hardcoded ID” trap — works in the demo, fails in any custom setup.
How has this ever worked for anybody else ? 

Also, exactly why github commit removes the trailing brace and then re-adds it, is one of the remaining mysteries of life.
Apparently, GitHub’s web-editor/diff-formatter automatically normalizes whitespace, line endings, or braces when you edit in the browser - according to ChatGPT.